### PR TITLE
Add Sender / Receiver traits.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "lifeline"
-description = "Lifeline is a dependency injection library for message-based applications."
 version = "0.1.0"
-authors = ["Austin Jones <austinbaysjones@gmail.com>"]
+description = "Lifeline is a dependency injection library for message-based applications."
+keywords = ["async", "tokio", "async", "actor", "actors"]
+categories = ["Asynchronous", "Rust patterns"]
+authors = ["Austin Jones <implAustin@gmail.com>"]
 edition = "2018"
 license = "MIT"
 
@@ -11,7 +13,6 @@ license = "MIT"
 [dependencies]
 pin-project = "0.4.23"
 futures = "0.3"
-tokio = { version = "0.2", features = ["sync", "rt-core"] }
 uuid = { version = "0.8", features = ["serde", "v4"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 lru = { version = "0.6.0", optional = true }
@@ -27,10 +28,13 @@ downcast-rs = "1.2.0"
 log = "0.4"
 regex = "1.3"
 
+
+tokio = { version = "0.2", features = ["stream", "sync", "rt-core"] }
+
 [dev-dependencies]
 anyhow = "1.0"
 simple_logger = "1.6"
-tokio = { version = "0.2", features = ["sync", "time", "macros", "rt-threaded"] }
+tokio = { version = "0.2", features = ["stream", "sync", "time", "macros", "rt-threaded"] }
 
 [features]
 default = ["serialize"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lifeline"
-version = "0.1.0"
+version = "0.2.0"
 description = "Lifeline is a dependency injection library for message-based applications."
 keywords = ["async", "tokio", "async", "actor", "actors"]
 categories = ["Asynchronous", "Rust patterns"]

--- a/examples/associated.rs
+++ b/examples/associated.rs
@@ -1,0 +1,101 @@
+use bus::ExampleBus;
+use lifeline::prelude::*;
+use message::*;
+use service::ExampleService;
+
+/// If a service spawns many tasks, it helps to break the run functions up.  
+/// You can do this by defining associated functions on the service type,
+///   and calliing them with Self::run_something(rx, tx)  
+#[tokio::main]
+pub async fn main() -> anyhow::Result<()> {
+    let bus = ExampleBus::default();
+    let _service = ExampleService::spawn(&bus)?;
+
+    let mut rx = bus.rx::<ExampleSend>()?;
+    let mut tx = bus.tx::<ExampleRecv>()?;
+
+    tx.send(ExampleRecv::Hello).await?;
+
+    let oh_hello = rx.recv().await;
+    assert_eq!(Some(ExampleSend::OhHello), oh_hello);
+    println!("Service says {:?}", oh_hello.unwrap());
+
+    Ok(())
+}
+
+mod bus {
+    use crate::message::*;
+    use lifeline::prelude::*;
+    use tokio::sync::broadcast;
+
+    lifeline_bus!(pub struct ExampleBus);
+
+    impl Message<ExampleBus> for ExampleRecv {
+        type Channel = broadcast::Sender<Self>;
+    }
+
+    impl Message<ExampleBus> for ExampleSend {
+        type Channel = broadcast::Sender<Self>;
+    }
+}
+
+mod message {
+    #[derive(Debug, Clone)]
+    pub enum ExampleRecv {
+        Hello,
+    }
+
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub enum ExampleSend {
+        OhHello,
+    }
+}
+
+mod service {
+    use crate::bus::ExampleBus;
+    use crate::message::*;
+    use lifeline::prelude::*;
+
+    pub struct ExampleService {
+        _greet: Lifeline,
+    }
+
+    impl Service for ExampleService {
+        type Bus = ExampleBus;
+        type Lifeline = anyhow::Result<Self>;
+
+        fn spawn(bus: &Self::Bus) -> Self::Lifeline {
+            // The generic args here are required, by design.
+            // Type inference would be nice, but if you type the message name here,
+            //   you can GREP THE NAME!  Just search an event name and you'll see:
+            // - which bus(es) the event is carried on
+            // - which services rx the event
+            // - which services tx the event
+
+            // also, rx before tx!  somewhat like fn service(rx) -> tx {}
+            let rx = bus.rx::<ExampleRecv>()?;
+            let tx = bus.tx::<ExampleSend>()?;
+
+            let _greet = Self::try_task("greet", Self::run_greet(rx, tx));
+
+            Ok(Self { _greet })
+        }
+    }
+
+    impl ExampleService {
+        async fn run_greet(
+            mut rx: impl Receiver<ExampleRecv>,
+            mut tx: impl Sender<ExampleSend>,
+        ) -> anyhow::Result<()> {
+            while let Some(recv) = rx.recv().await {
+                match recv {
+                    ExampleRecv::Hello => {
+                        tx.send(ExampleSend::OhHello).await?;
+                    }
+                }
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/examples/associated.rs
+++ b/examples/associated.rs
@@ -65,14 +65,6 @@ mod service {
         type Lifeline = anyhow::Result<Self>;
 
         fn spawn(bus: &Self::Bus) -> Self::Lifeline {
-            // The generic args here are required, by design.
-            // Type inference would be nice, but if you type the message name here,
-            //   you can GREP THE NAME!  Just search an event name and you'll see:
-            // - which bus(es) the event is carried on
-            // - which services rx the event
-            // - which services tx the event
-
-            // also, rx before tx!  somewhat like fn service(rx) -> tx {}
             let rx = bus.rx::<ExampleRecv>()?;
             let tx = bus.tx::<ExampleSend>()?;
 

--- a/examples/carrier.rs
+++ b/examples/carrier.rs
@@ -2,8 +2,6 @@ use bus::{MainBus, SubsurfaceBus};
 use lifeline::prelude::*;
 use message::{main::MainSend, subsurface::SubsurfaceSend};
 use service::HelloService;
-use std::time::Duration;
-use tokio::{sync::mpsc::error::TryRecvError, time::delay_for};
 
 /// This examples shows how to communicate between Bus instances using the CarryFrom trait
 /// When your application gets large, eventually you need to spawn new tasks as runtime (when a connection arrives)

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -23,13 +23,13 @@ pub async fn main() -> anyhow::Result<()> {
     // there is an important naming convention here
     // tx - for Sender channels
     // rx - for Recevier channels
-    // ExampleSend - a message which is sent to the service (and the service receives)
-    // ExampleRecv - a message which is sent to the world (and the service sends)
+    // ExampleSend - a message which is sent to the world (and the service sends)
+    // ExampleRecv - a message which is sent to the service (and the service receives)
 
-    // this side of the channel is 'covariant'.
-    //   we tx a 'send' msg, and rx a 'recv' message.
+    // this side of the channel is 'contravariant'.
+    //   we rx a 'send' msg, and tx a 'recv' message.
     // if we were in the service,
-    //   we would tx a 'recv' message, and 'rx' a send message
+    //   we would rx a 'recv' message, and 'tx' a send message
     // this naming convention helps a lot when reading code
 
     // taking receivers out of the bus is fallible.  behavior depends on the channel type
@@ -41,6 +41,10 @@ pub async fn main() -> anyhow::Result<()> {
     //   broadcast:  clone Sender / clone Receiver
     //   oneshot:    take Sender  / take  Receiver
     //   watch:      take Sender  / clone Receiver
+
+    // lifeline also tries to make the channel type easy to change.
+    // it wraps the concrete sender/receiver types in an adapter type,
+    // which implements the lifeline::Sender / lifeline::Receiver trait
     let mut rx = bus.rx::<ExampleSend>()?;
     let mut tx = bus.tx::<ExampleRecv>()?;
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,4 +1,5 @@
 use crate::{
+    channel::lifeline::{receiver::LifelineReceiver, sender::LifelineSender},
     error::{AlreadyLinkedError, TakeChannelError, TakeResourceError},
     Channel, Storage,
 };
@@ -25,11 +26,15 @@ pub trait Bus: Default + Debug + Sized {
     where
         Msg: Message<Self> + 'static;
 
-    fn rx<Msg>(&self) -> Result<<Msg::Channel as Channel>::Rx, TakeChannelError>
+    fn rx<Msg>(
+        &self,
+    ) -> Result<LifelineReceiver<Msg, <Msg::Channel as Channel>::Rx>, TakeChannelError>
     where
         Msg: Message<Self> + 'static;
 
-    fn tx<Msg>(&self) -> Result<<Msg::Channel as Channel>::Tx, TakeChannelError>
+    fn tx<Msg>(
+        &self,
+    ) -> Result<LifelineSender<Msg, <Msg::Channel as Channel>::Tx>, TakeChannelError>
     where
         Msg: Message<Self> + 'static;
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,6 +1,7 @@
 use crate::Storage;
 
 mod futures;
+pub mod lifeline;
 // pub mod historical;
 pub mod subscription;
 mod tokio;

--- a/src/channel/lifeline.rs
+++ b/src/channel/lifeline.rs
@@ -1,0 +1,19 @@
+pub(crate) mod receiver;
+pub(crate) mod sender;
+use async_trait::async_trait;
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("send error: {0:?}")]
+pub struct SendError<T: Debug>(pub T);
+
+#[async_trait]
+pub trait Sender<T: Debug> {
+    async fn send(&mut self, value: T) -> Result<(), SendError<T>>;
+}
+
+#[async_trait]
+pub trait Receiver<T> {
+    async fn recv(&mut self) -> Option<T>;
+}

--- a/src/channel/lifeline/receiver.rs
+++ b/src/channel/lifeline/receiver.rs
@@ -1,0 +1,91 @@
+use super::Receiver;
+use async_trait::async_trait;
+use log::{trace, warn};
+use pin_project::pin_project;
+use std::{
+    fmt::Debug,
+    marker::{PhantomData, Send},
+};
+
+#[pin_project(project = InnerProjection)]
+pub struct LifelineReceiver<T, R> {
+    #[pin]
+    inner: R,
+    log: bool,
+    // will the channel stop if there are
+    strict: bool,
+    _t: PhantomData<T>,
+}
+
+impl<T, R> LifelineReceiver<T, R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            log: false,
+            strict: false,
+            _t: PhantomData,
+        }
+    }
+
+    pub fn strict(mut self) -> Self {
+        self.strict = true;
+        self
+    }
+
+    pub fn log(mut self) -> Self {
+        self.log = true;
+        self
+    }
+
+    pub fn inner(&self) -> &R {
+        &self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<T, R: Debug> Debug for LifelineReceiver<T, R> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("Receiver")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl<T, R> Receiver<T> for LifelineReceiver<T, R>
+where
+    T: Send + Debug,
+    R: Send + Receiver<T>,
+{
+    async fn recv(&mut self) -> Option<T> {
+        self.inner.recv().await
+    }
+}
+
+mod tokio {
+    use super::LifelineReceiver;
+    use std::{
+        pin::Pin,
+        task::{Context, Poll},
+    };
+    use tokio::stream::Stream;
+
+    impl<T, R> Stream for LifelineReceiver<T, R>
+    where
+        R: Stream<Item = T>,
+    {
+        type Item = T;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let project = self.project();
+            project.inner.poll_next(cx)
+        }
+    }
+}

--- a/src/channel/lifeline/receiver.rs
+++ b/src/channel/lifeline/receiver.rs
@@ -1,6 +1,6 @@
 use super::Receiver;
 use async_trait::async_trait;
-use log::{trace, warn};
+
 use pin_project::pin_project;
 use std::{
     fmt::Debug,

--- a/src/channel/lifeline/sender.rs
+++ b/src/channel/lifeline/sender.rs
@@ -1,9 +1,8 @@
 use super::{SendError, Sender};
 use async_trait::async_trait;
 use log::trace;
-use pin_project::pin_project;
+
 use std::{fmt::Debug, marker::PhantomData};
-use thiserror::Error;
 
 pub struct LifelineSender<T, S> {
     inner: S,

--- a/src/channel/lifeline/sender.rs
+++ b/src/channel/lifeline/sender.rs
@@ -1,0 +1,70 @@
+use super::{SendError, Sender};
+use async_trait::async_trait;
+use log::trace;
+use pin_project::pin_project;
+use std::{fmt::Debug, marker::PhantomData};
+use thiserror::Error;
+
+pub struct LifelineSender<T, S> {
+    inner: S,
+    log: bool,
+    _t: PhantomData<T>,
+}
+
+impl<T, S> LifelineSender<T, S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            log: false,
+            _t: PhantomData,
+        }
+    }
+
+    pub fn log(mut self) -> Self {
+        self.log = true;
+        self
+    }
+
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+#[async_trait]
+impl<T, S> Sender<T> for LifelineSender<T, S>
+where
+    T: Send + Debug,
+    S: Send + Sender<T>,
+{
+    async fn send(&mut self, value: T) -> Result<(), SendError<T>> {
+        let log = if self.log && log::log_enabled!(log::Level::Trace) {
+            Some(format!("SEND {:?}", &value))
+        } else {
+            None
+        };
+
+        let result = self.inner.send(value).await;
+
+        if let Some(log) = log {
+            trace!("{}", log);
+        }
+
+        result
+    }
+}
+
+impl<T, S: Debug> Debug for LifelineSender<T, S> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt.debug_struct("Receiver")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}

--- a/src/channel/subscription.rs
+++ b/src/channel/subscription.rs
@@ -26,9 +26,9 @@ where
             .rx::<messages::SubscriptionState<T>>()
             .expect("rx SubscriptionState<T>");
 
-        let sender = channel::Sender::new(tx, service);
+        let sender = channel::Sender::new(tx.into_inner(), service);
 
-        let receiver = channel::Receiver::new(rx);
+        let receiver = channel::Receiver::new(rx.into_inner());
         (sender, receiver)
     }
 
@@ -207,8 +207,8 @@ mod service {
         type Lifeline = anyhow::Result<Lifeline>;
 
         fn spawn(bus: &Self::Bus) -> Self::Lifeline {
-            let mut rx = bus.rx::<Subscription<T>>()?;
-            let tx = bus.tx::<SubscriptionState<T>>()?;
+            let mut rx = bus.rx::<Subscription<T>>()?.into_inner();
+            let tx = bus.tx::<SubscriptionState<T>>()?.into_inner();
             let mut next_id = 0usize;
             let lifeline = Self::try_task("run", async move {
                 let mut state = SubscriptionState::default();

--- a/src/dyn_bus.rs
+++ b/src/dyn_bus.rs
@@ -3,10 +3,10 @@ mod slot;
 mod storage;
 
 use crate::{
-    bus::{Link, Message, Resource},
+    bus::{Message, Resource},
     channel::lifeline::{receiver::LifelineReceiver, sender::LifelineSender},
-    error::{type_name, AlreadyLinkedError, TakeChannelError, TakeResourceError},
-    Bus, Channel, Storage,
+    error::{AlreadyLinkedError, TakeChannelError, TakeResourceError},
+    Bus, Channel,
 };
 
 pub use storage::DynBusStorage;

--- a/src/dyn_bus/slot.rs
+++ b/src/dyn_bus/slot.rs
@@ -1,16 +1,6 @@
-use crate::{
-    bus::{Link, Message, Resource},
-    error::{type_name, AlreadyLinkedError, TakeChannelError, TakeResourceError},
-    Bus, Channel, Storage,
-};
+use crate::{error::type_name, Channel, Storage};
 
-use std::{
-    any::{Any, TypeId},
-    collections::{HashMap, HashSet},
-    fmt::Debug,
-    marker::PhantomData,
-    sync::{RwLock, RwLockWriteGuard},
-};
+use std::{any::Any, fmt::Debug};
 
 pub(crate) struct BusSlot {
     name: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod bus;
 mod channel;
 pub mod dyn_bus;
 pub mod error;
+pub mod prelude;
 pub mod request;
 mod service;
 mod spawn;
@@ -11,6 +12,7 @@ mod storage;
 pub mod test;
 
 pub use bus::*;
+pub use channel::lifeline::{Receiver, Sender};
 pub use channel::subscription;
 pub use channel::Channel;
 pub use service::*;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,3 @@
+pub use crate::{
+    lifeline_bus, Bus, CarryFrom, CarryInto, Lifeline, Message, Receiver, Sender, Service, Task,
+};

--- a/src/service.rs
+++ b/src/service.rs
@@ -30,32 +30,32 @@ where
     }
 }
 
-pub trait FromCarrier<IntoBus: Bus>: Bus + Task + Sized {
+pub trait CarryFrom<IntoBus: Bus>: Bus + Task + Sized {
     type Lifeline;
 
     fn carry_from(&self, from: &IntoBus) -> Self::Lifeline;
 }
 
-pub trait IntoCarrier<IntoBus: Bus>: Bus + Task + Sized {
+pub trait CarryInto<IntoBus: Bus>: Bus + Task + Sized {
     type Lifeline;
 
     fn carry_into(&self, into: &IntoBus) -> Self::Lifeline;
 }
 
-impl<F, I> IntoCarrier<I> for F
+impl<F, I> CarryInto<I> for F
 where
-    I: FromCarrier<F>,
+    I: CarryFrom<F>,
     F: Bus,
     I: Bus,
 {
-    type Lifeline = <I as FromCarrier<F>>::Lifeline;
+    type Lifeline = <I as CarryFrom<F>>::Lifeline;
 
     fn carry_into(&self, into: &I) -> Self::Lifeline {
         into.carry_from(self)
     }
 }
 
-pub trait DefaultCarrier<FromBus: Bus>: FromCarrier<FromBus> {
+pub trait DefaultCarrier<FromBus: Bus>: CarryFrom<FromBus> {
     fn carry_default() -> (Self, FromBus, Self::Lifeline) {
         let into = Self::default();
         let from = FromBus::default();


### PR DESCRIPTION
Add traits to generalize Sender & Receivers.

This makes applications with tons of channels much easier to change, and much easier to learn (senders go ?, receivers are Some).

It also smooths over the tokio err types that don't implement std::error::Error, and are really akward w/ anyhow.

It also allows 'impl Sender<T>' in the arguments for a service Self::run_xyz function.