### PR TITLE
Implement clone for LifelineSender & LifelineReceiver #24

### DIFF
--- a/src/channel/lifeline/sender.rs
+++ b/src/channel/lifeline/sender.rs
@@ -67,3 +67,16 @@ impl<T, S: Debug> Debug for LifelineSender<T, S> {
             .finish()
     }
 }
+
+impl<T, S> Clone for LifelineSender<T, S>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            log: self.log,
+            _t: PhantomData,
+        }
+    }
+}


### PR DESCRIPTION
This allows users to write `impl Sender<MyStruct> + Clone`.

Also add logging to LifelineReceiver if log is on.

Closes #24 