### PR TITLE
[TASK] Update to Tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,21 +29,22 @@ anyhow = "1.0"
 log = "0.4"
 regex = "1.3"
 
-tokio = { version = "0.2", default-features = false, optional = true }
+tokio = { version = "1.0", default-features = false, optional = true }
+tokio-stream = { version = "0.1", optional = true }
 async-std = { version = "1.6", default-features = false, optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
 simple_logger = "1.9"
-tokio = { version = "0.2", features = ["sync", "time", "macros"] }
+tokio = { version = "1.0", features = ["sync", "time", "macros", "rt-multi-thread"] }
 
 [features]
 default = ["barrier-channel", "dyn-bus", "tokio-executor", "tokio-channels"]
 
 dyn-bus = []
 
-tokio-executor = ["tokio/rt-core"]
-tokio-channels = ["tokio/stream", "tokio/sync"]
+tokio-executor = ["tokio/rt"]
+tokio-channels = ["tokio-stream", "tokio/sync"]
 
 async-std-executor = ["async-std/default"]
 async-std-channels = ["async-std/unstable"]

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -5,7 +5,7 @@ use service::{MainService, StateService};
 use simple_logger::SimpleLogger;
 use state::{LocationState, SkyState, WeatherState};
 use std::time::Duration;
-use tokio::time::delay_for;
+use tokio::time::sleep;
 
 /// This example shows how to maintain state in a service, and broadcast it using channels.
 /// For documentation on basic concepts (bus/service/channels), see the 'hello' example.
@@ -32,7 +32,7 @@ pub async fn main() -> anyhow::Result<()> {
     tx.send(MainRecv::Travel(LocationState::Boston)).await?;
 
     // state updates are asynchronous.  they may not be propagated immediately
-    delay_for(Duration::from_millis(20)).await;
+    sleep(Duration::from_millis(20)).await;
 
     let state = rx.recv().await;
     let expected = SkyState {
@@ -49,7 +49,7 @@ pub async fn main() -> anyhow::Result<()> {
     tx.send(MainRecv::Travel(LocationState::SanDiego)).await?;
 
     // state updates are asynchronous.  they may not be propagated immediately
-    delay_for(Duration::from_millis(20)).await;
+    sleep(Duration::from_millis(20)).await;
 
     let state = rx.recv().await;
     let expected = SkyState {
@@ -249,7 +249,7 @@ mod service {
                     // this is actually useful - disconnected channels propagate shutdowns.
                     // in this case, if all the receivers have disconnected,
                     //   we can stop calculating the state.
-                    tx.broadcast(state.clone())?;
+                    tx.send(state.clone())?;
                 }
 
                 Ok(())

--- a/examples/subscription.rs
+++ b/examples/subscription.rs
@@ -18,7 +18,7 @@ pub async fn main() -> anyhow::Result<()> {
     // updates are asynchronous.
     // they are processed using lifeline that is stored in the sender
     tx.send(Subscription::Subscribe(ExampleId(1))).await?;
-    time::delay_for(Duration::from_millis(100)).await;
+    time::sleep(Duration::from_millis(100)).await;
 
     // the receiver can check whether an id is contained in the subscription
     assert!(rx.contains(&ExampleId(1)));

--- a/src/channel/lifeline/receiver.rs
+++ b/src/channel/lifeline/receiver.rs
@@ -94,7 +94,7 @@ mod tokio {
         pin::Pin,
         task::{Context, Poll},
     };
-    use tokio::stream::Stream;
+    use tokio_stream::Stream;
 
     impl<T, R> Stream for LifelineReceiver<T, R>
     where

--- a/src/channel/tokio.rs
+++ b/src/channel/tokio.rs
@@ -44,7 +44,7 @@ where
     }
 }
 
-impl<T: Send + 'static> Channel for broadcast::Sender<T> {
+impl<T: Send + Clone + 'static> Channel for broadcast::Sender<T> {
     type Tx = Self;
     type Rx = broadcast::Receiver<T>;
 
@@ -96,8 +96,8 @@ where
 
             match result {
                 Ok(t) => return Some(t),
-                Err(broadcast::RecvError::Closed) => return None,
-                Err(broadcast::RecvError::Lagged(n)) => {
+                Err(broadcast::error::RecvError::Closed) => return None,
+                Err(broadcast::error::RecvError::Lagged(n)) => {
                     // we keep the broadcast complexity localized here.
                     // instead of making things very complicated for mpsc, watch, etc receivers,
                     // we log a debug message when a lag occurs, even if logging was not requested.
@@ -151,7 +151,7 @@ where
     T: Clone + Debug + Send + Sync,
 {
     async fn send(&mut self, value: T) -> Result<(), LifelineSendError<T>> {
-        watch::Sender::broadcast(self, value).map_err(|_| LifelineSendError::Closed)
+        watch::Sender::send(self, value).map_err(|_| LifelineSendError::Closed)
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,9 +4,11 @@
 /// This is helpful in doctests
 #[cfg(feature = "tokio-executor")]
 pub fn block_on<Fut: std::future::Future<Output = Out>, Out>(fut: Fut) -> Out {
-    use tokio::runtime::Runtime;
+    use tokio::runtime::Builder;
 
-    let mut runtime = Runtime::new().expect("doctest runtime creation failed");
+    let runtime = Builder::new_current_thread()
+        .build()
+        .expect("doctest runtime creation failed");
     runtime.block_on(fut)
 }
 
@@ -27,12 +29,12 @@ pub fn block_on<Fut: std::future::Future<Output = Out>, Out>(fut: Fut) -> Out {
 ///
 /// ```rust
 /// use lifeline::assert_completes;
-/// use tokio::time::delay_for;
+/// use tokio::time::sleep;
 ///
 /// # let fut =
 /// async {
 ///     // Succeeds because default time is longer than delay.
-///     assert_completes!(delay_for(Duration::from_millis(5)));
+///     assert_completes!(sleep(Duration::from_millis(5)));
 /// }
 /// # ;
 /// # let mut runtime = tokio::runtime::Runtime::new().unwrap();
@@ -41,12 +43,12 @@ pub fn block_on<Fut: std::future::Future<Output = Out>, Out>(fut: Fut) -> Out {
 ///
 /// ```rust,should_panic
 /// use lifeline::assert_completes;
-/// use tokio::time::delay_for;
+/// use tokio::time::sleep;
 ///
 /// # let fut =
 /// async {
 ///     // Fails because timeout is shorter than delay.
-///     assert_completes!(delay_for(Duration::from_millis(250)), 10);
+///     assert_completes!(sleep(Duration::from_millis(250)), 10);
 /// }
 /// # ;
 /// # let mut runtime = tokio::runtime::Runtime::new().unwrap();
@@ -84,12 +86,12 @@ macro_rules! assert_completes {
 ///
 /// ```rust,should_panic
 /// use lifeline::assert_times_out;
-/// use tokio::time::delay_for;
+/// use tokio::time::sleep;
 ///
 /// # let fut =
 /// async {
 ///     // Fails because default time is longer than delay.
-///     assert_times_out!(delay_for(Duration::from_millis(5)));
+///     assert_times_out!(sleep(Duration::from_millis(5)));
 /// }
 /// # ;
 /// # let mut runtime = tokio::runtime::Runtime::new().unwrap();
@@ -98,12 +100,12 @@ macro_rules! assert_completes {
 ///
 /// ```rust
 /// use lifeline::assert_times_out;
-/// use tokio::time::delay_for;
+/// use tokio::time::sleep;
 ///
 /// # let fut =
 /// async {
 ///     // Succeeds because timeout is shorter than delay.
-///     assert_times_out!(delay_for(Duration::from_millis(250)), 10);
+///     assert_times_out!(sleep(Duration::from_millis(250)), 10);
 /// }
 /// # ;
 /// # let mut runtime = tokio::runtime::Runtime::new().unwrap();


### PR DESCRIPTION
Changes for tokio-0.3 compatibility:

* time::delay_for renamed to time::sleep
* watch::Sender::broadcast renamed to watch::Sender::send
* "rt-multi-thread" feature required for tests to use `#[tokio::main]` macro
* "rt-core" feature renamed to "rt"
* broadcast::RecvError moved to broadcast::error::RecvError

Changes for Tokio 1.0 compatibility:

* tokio::stream::Stream move to tokio-stream crate
